### PR TITLE
[CS-2337] Fix user-agent validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gasbuddy/configured-swagger-client",
-  "version": "5.5.1",
+  "version": "5.5.2",
   "description": "A module that creates a set of swagger clients with support for inter-service tracing, custom certificates, and separated endpoint configuration",
   "main": "build/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gasbuddy/configured-swagger-client",
-  "version": "5.5.0",
+  "version": "5.5.1",
   "description": "A module that creates a set of swagger clients with support for inter-service tracing, custom certificates, and separated endpoint configuration",
   "main": "build/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -46,14 +46,9 @@ function serviceFactory(swaggerConfigurator, req) {
         request.headers = request.headers || {};
         if (!noTracing) {
           request.headers.correlationid = req.headers?.correlationid;
+          request.headers['user-agent'] = req.headers?.['user-agent'];
           newSpanLogger = req.gb?.logger?.loggerWithNewSpan?.();
           request.headers.span = newSpanLogger?.spanId;
-          const ua = request.headers['user-agent'];
-          const isReplaceableUA = !ua || (typeof ua === 'string' && ua.includes('node-fetch'));
-
-          if (isReplaceableUA && req.headers?.['user-agent']) {
-            request.headers['user-agent'] = req.headers['user-agent'];
-          }
         }
         if ((log || logEverything) && req.gb?.logger) {
           req.gb.logger.info('api-req', {

--- a/src/index.js
+++ b/src/index.js
@@ -49,7 +49,7 @@ function serviceFactory(swaggerConfigurator, req) {
           newSpanLogger = req.gb?.logger?.loggerWithNewSpan?.();
           request.headers.span = newSpanLogger?.spanId;
           const ua = request.headers['user-agent'];
-          const isReplaceableUA = typeof ua === 'string' && ua.includes('node-fetch');
+          const isReplaceableUA = !ua || (typeof ua === 'string' && ua.includes('node-fetch'));
 
           if (isReplaceableUA && req.headers?.['user-agent']) {
             request.headers['user-agent'] = req.headers['user-agent'];

--- a/src/index.js
+++ b/src/index.js
@@ -46,7 +46,9 @@ function serviceFactory(swaggerConfigurator, req) {
         request.headers = request.headers || {};
         if (!noTracing) {
           request.headers.correlationid = req.headers?.correlationid;
-          request.headers['user-agent'] = req.headers?.['user-agent'];
+          if (!request.headers['user-agent']) {
+            request.headers['user-agent'] = req.headers?.['user-agent'];
+          }
           newSpanLogger = req.gb?.logger?.loggerWithNewSpan?.();
           request.headers.span = newSpanLogger?.spanId;
         }


### PR DESCRIPTION
Running tests on vehicle-api and user-content-serv, we could see that the user-agent is undefined at this point, so Im removing all the logic that was trying to replace only node-fetch UA.

Not sure how to test this change for a real scenario in this repo, other than just manually add the header [here](https://github.com/gas-buddy/configured-swagger-client/blob/master/src/index.js#L124) and [here](https://github.com/gas-buddy/configured-swagger-client/blob/master/test/swagger/index.js#L43-L45) but Im actually hardcoding the headers.